### PR TITLE
Fix signal handling in start-l2met-shuttle to ensure clean shutdown.

### DIFF
--- a/support/start-l2met-shuttle
+++ b/support/start-l2met-shuttle
@@ -17,8 +17,9 @@ run-l2met-shuttle() {
   mkfifo --mode=600 "$pipe"
 
   (<"$pipe" .heroku/l2met-shuttle/bin/l2met-shuttle "${L2MET_SHUTTLE_URL:?}") &
+  exec > >(exec tee "$pipe") 2> >(exec tee "$pipe" >&2)
 
-  "$@" > >(tee "$pipe") 2> >(tee "$pipe" >&2)
+  "$@" 
 }
 
 is-enabled() {

--- a/support/start-l2met-shuttle
+++ b/support/start-l2met-shuttle
@@ -12,14 +12,11 @@ main() {
 }
 
 run-l2met-shuttle() {
-  declare pipe
-  pipe=$(mktemp -u)
-  mkfifo --mode=600 "$pipe"
+  exec \
+    1> >(exec .heroku/l2met-shuttle/bin/l2met-shuttle --tee "${L2MET_SHUTTLE_URL:?}") \
+    2> >(exec .heroku/l2met-shuttle/bin/l2met-shuttle --tee "${L2MET_SHUTTLE_URL:?}" >&2)
 
-  (<"$pipe" .heroku/l2met-shuttle/bin/l2met-shuttle "${L2MET_SHUTTLE_URL:?}") &
-  exec > >(exec tee "$pipe") 2> >(exec tee "$pipe" >&2)
-
-  "$@" 
+  exec "$@" 
 }
 
 is-enabled() {

--- a/support/start-l2met-shuttle
+++ b/support/start-l2met-shuttle
@@ -18,7 +18,7 @@ run-l2met-shuttle() {
 
   (<"$pipe" .heroku/l2met-shuttle/bin/l2met-shuttle "${L2MET_SHUTTLE_URL:?}") &
 
-  exec "$@" > >(tee "$pipe") 2> >(tee "$pipe" >&2)
+  "$@" > >(tee "$pipe") 2> >(tee "$pipe" >&2)
 }
 
 is-enabled() {


### PR DESCRIPTION
Leaving the shell running (04cfd0f) makes the greatest difference. The rest of this change tidies up the process tree.