### PR TITLE
handle sigterm properly

### DIFF
--- a/support/start-l2met-shuttle
+++ b/support/start-l2met-shuttle
@@ -18,6 +18,15 @@ main() {
 }
 
 run-l2met-shuttle() {
+  # run the provided command ("$@") using l2met-shuttle's
+  # `-tee` mode instead of using a fifo like the previous mechanism.
+  # The old mechanism (see git for the diff) used the `tee` program,
+  # and a named fifo (pipe) instead of using a normal pipe.
+  # This is because it was implemented before `l2met-shuttle` had the `-tee`
+  # option, and so we needed to copy stdout/stderr to this script's stdout/stderr
+  # explicitly.
+  # `-tee` fixes all of that, and means we can just use a normal pipe (once we redirect
+  # stderr to stdout anyway).
   exec "$@" 2>&1 | .heroku/l2met-shuttle/bin/l2met-shuttle -tee "${L2MET_SHUTTLE_URL:?}"
 }
 

--- a/support/start-l2met-shuttle
+++ b/support/start-l2met-shuttle
@@ -4,6 +4,9 @@
 set -eu -o pipefail
 
 _term() {
+    # we trap SIGTERM so that we can use `exec` on the
+    # command passed in, yet still not die when given
+    # SIGTERM
     echo "start-l2met-shuttle: received TERM, ignoring"
 }
 

--- a/support/start-l2met-shuttle
+++ b/support/start-l2met-shuttle
@@ -3,6 +3,12 @@
 
 set -eu -o pipefail
 
+_term() {
+    echo "start-l2met-shuttle: received TERM, ignoring"
+}
+
+trap _term SIGTERM
+
 main() {
   if ! is-enabled "${L2MET_SHUTTLE_ENABLE:-1}"; then
     exec "$@"
@@ -12,13 +18,7 @@ main() {
 }
 
 run-l2met-shuttle() {
-  declare pipe
-  pipe=$(mktemp -u)
-  mkfifo --mode=600 "$pipe"
-
-  (<"$pipe" .heroku/l2met-shuttle/bin/l2met-shuttle "${L2MET_SHUTTLE_URL:?}") &
-
-  exec "$@" > >(tee "$pipe") 2> >(tee "$pipe" >&2)
+  exec "$@" 2>&1 | .heroku/l2met-shuttle/bin/l2met-shuttle -tee "${L2MET_SHUTTLE_URL:?}"
 }
 
 is-enabled() {

--- a/support/start-l2met-shuttle
+++ b/support/start-l2met-shuttle
@@ -25,6 +25,8 @@ run-l2met-shuttle() {
   # This is because it was implemented before `l2met-shuttle` had the `-tee`
   # option, and so we needed to copy stdout/stderr to this script's stdout/stderr
   # explicitly.
+  # running `tee` itself was a problem for the SIGTERM handling, because `tee` itself
+  # just exits the moment it receives a TERM
   # `-tee` fixes all of that, and means we can just use a normal pipe (once we redirect
   # stderr to stdout anyway).
   exec "$@" 2>&1 | .heroku/l2met-shuttle/bin/l2met-shuttle -tee "${L2MET_SHUTTLE_URL:?}"


### PR DESCRIPTION
This rewrites `start-l2met-shuttle`, and uses a binary from https://github.com/heroku/l2met-shuttle/pull/14 that ignores `SIGTERM`

This is because, on heroku dynos, the dyno manager sends SIGTERM to every process when doing a graceful shutdown. During that time period, we still want logging to happen and metrics to be sent.

With the prior implementation, the `tee` processes would exit the moment the dyno got told to shutdown.

In the new implementation, `l2met-shuttle` hangs around until the process it's reading from dies.